### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/alm.js
+++ b/alm.js
@@ -51,7 +51,7 @@ function AlmViz(options) {
 
         if (showTitle) {
             vizDiv.append("a")
-                .attr('href', 'http://dx.doi.org/' + data[0].doi)
+                .attr('href', 'https://doi.org/' + data[0].doi)
                 .attr("class", "title")
                 .text(data[0].title);
         }


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!